### PR TITLE
[14.0][IMP] queue_job: automatically update dependent jobs when state changes manually

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -542,8 +542,8 @@ class Job(object):
 
         return self.result
 
-    def enqueue_waiting(self):
-        sql = """
+    def _get_common_dependent_jobs_query(self):
+        return """
             UPDATE queue_job
             SET state = %s
             FROM (
@@ -571,7 +571,15 @@ class Job(object):
             AND %s = ALL(jobs.parent_states)
             AND state = %s;
         """
+
+    def enqueue_waiting(self):
+        sql = self._get_common_dependent_jobs_query()
         self.env.cr.execute(sql, (PENDING, self.uuid, DONE, WAIT_DEPENDENCIES))
+        self.env["queue.job"].invalidate_cache(["state"])
+
+    def cancel_dependent_jobs(self):
+        sql = self._get_common_dependent_jobs_query()
+        self.env.cr.execute(sql, (CANCELLED, self.uuid, CANCELLED, WAIT_DEPENDENCIES))
         self.env["queue.job"].invalidate_cache(["state"])
 
     def store(self):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -308,6 +308,7 @@ class QueueJob(models.Model):
             if state == DONE:
                 job_.set_done(result=result)
                 job_.store()
+                record.env["queue.job"].flush()
                 job_.enqueue_waiting()
             elif state == PENDING:
                 job_.set_pending(result=result)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -316,6 +316,8 @@ class QueueJob(models.Model):
             elif state == CANCELLED:
                 job_.set_cancelled(result=result)
                 job_.store()
+                record.env["queue.job"].flush()
+                job_.cancel_dependent_jobs()
             else:
                 raise ValueError("State not supported: %s" % state)
 

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -16,6 +16,7 @@ from odoo.addons.queue_job.exception import (
     RetryableJobError,
 )
 from odoo.addons.queue_job.job import (
+    CANCELLED,
     DONE,
     ENQUEUED,
     FAILED,
@@ -548,6 +549,24 @@ class TestJobModel(JobCommonCase):
         # Check the state
         self.assertEqual(record_root.state, DONE)
         self.assertEqual(record_child.state, PENDING)
+
+    def test_button_cancel_dependencies(self):
+        job_root = Job(self.env["test.queue.job"].testing_method)
+        job_child = Job(self.env["test.queue.job"].testing_method)
+        job_child.add_depends({job_root})
+
+        DelayableGraph._ensure_same_graph_uuid([job_root, job_child])
+        job_root.store()
+        job_child.store()
+
+        self.assertEqual(job_child.state, WAIT_DEPENDENCIES)
+        record_root = job_root.db_record()
+        record_child = job_child.db_record()
+        # Trigger button cancelled
+        record_root.button_cancelled()
+        # Check the state
+        self.assertEqual(record_root.state, CANCELLED)
+        self.assertEqual(record_child.state, CANCELLED)
 
     def test_requeue(self):
         stored = self._create_job()

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -531,6 +531,24 @@ class TestJobModel(JobCommonCase):
             stored.result, "Manually set to done by %s" % self.env.user.name
         )
 
+    def test_button_done_enqueue_waiting_dependencies(self):
+        job_root = Job(self.env["test.queue.job"].testing_method)
+        job_child = Job(self.env["test.queue.job"].testing_method)
+        job_child.add_depends({job_root})
+
+        DelayableGraph._ensure_same_graph_uuid([job_root, job_child])
+        job_root.store()
+        job_child.store()
+
+        self.assertEqual(job_child.state, WAIT_DEPENDENCIES)
+        record_root = job_root.db_record()
+        record_child = job_child.db_record()
+        # Trigger button done
+        record_root.button_done()
+        # Check the state
+        self.assertEqual(record_root.state, DONE)
+        self.assertEqual(record_child.state, PENDING)
+
     def test_requeue(self):
         stored = self._create_job()
         stored.write({"state": "failed"})


### PR DESCRIPTION
- If a user explicitly cancels a job, he expects its child jobs to be canceled as well;
- However if a job fails, child jobs will stay in WAIT_DEPENDENCIES state; an action is expected from user to fix it and job might succeed after being re-queued